### PR TITLE
Add CI test for python3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
 language: python
 python:
   - "2.7"
+  - "3.5"
   - "3.6"
 before_install:
   - "export DISPLAY=:99.0"

--- a/searx/__init__.py
+++ b/searx/__init__.py
@@ -19,6 +19,7 @@ import certifi
 import logging
 from os import environ
 from os.path import realpath, dirname, join, abspath, isfile
+from io import open
 from ssl import OPENSSL_VERSION_INFO, OPENSSL_VERSION
 try:
     from yaml import load
@@ -50,7 +51,7 @@ if not settings_path:
     raise Exception('settings.yml not found')
 
 # load settings
-with open(settings_path, 'rb') as settings_yaml:
+with open(settings_path, 'r', encoding='utf-8') as settings_yaml:
     settings = load(settings_yaml)
 
 '''

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -19,6 +19,7 @@ along with searx. If not, see < http://www.gnu.org/licenses/ >.
 import sys
 import threading
 from os.path import realpath, dirname
+from io import open
 from flask_babel import gettext
 from operator import itemgetter
 from json import loads
@@ -36,7 +37,7 @@ engines = {}
 
 categories = {'general': []}
 
-languages = loads(open(engine_dir + '/../data/engines_languages.json', 'rb').read())
+languages = loads(open(engine_dir + '/../data/engines_languages.json', 'r', encoding='utf-8').read())
 
 engine_shortcuts = {}
 engine_default_args = {'paging': False,

--- a/searx/engines/currency_convert.py
+++ b/searx/engines/currency_convert.py
@@ -4,6 +4,7 @@ import os
 import sys
 import unicodedata
 
+from io import open
 from datetime import datetime
 
 if sys.version_info[0] == 3:
@@ -94,7 +95,7 @@ def load():
     global db
 
     current_dir = os.path.dirname(os.path.realpath(__file__))
-    json_data = open(current_dir + "/../data/currencies.json", 'rb').read()
+    json_data = open(current_dir + "/../data/currencies.json", 'r', encoding='utf-8').read()
 
     db = json.loads(json_data)
 


### PR DESCRIPTION
Python3.5 is still the default Python3 version in
Debian Stretch (stable) and Ubuntu 16.04 LTS
https://packages.debian.org/source/stretch/python3-defaults
https://packages.ubuntu.com/source/xenial/python/python3-defaults